### PR TITLE
Add 1.26 release team shadow analysis config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -52,7 +52,32 @@ CHART_SCHEMA_DEFINITIONS = {
                    ["Will you be able to attend Burndown meetings?"],
                    plotting_count_entities_up, {CLEAN_THRESHOLD: 2})
     ],
-    K8s_126: []
+    K8s_126: [
+        BasicChart("affiliation", ["Company Affiliation / Employer"],
+                   plotting_count_entities_up,
+                   {CLEAN_KEYWORDS: company_keywords, CLEAN_THRESHOLD: 2}),
+        BasicChart("Timezone",
+                   ["What time zone are you normally in?", "What time zone are you normally in?.1"],
+                   plotting_count_entities_up, {CLEAN_ALIAS: timezone_aliases, CLEAN_THRESHOLD: 2}),
+        BasicChart("Interested in Teams", ["Which Release Team roles are you interested in?",
+                                           "Which Release Team roles are you interested for 1.26?"],
+                   plotting_count_entities_up, {CLEAN_SPLIT_INTO_KEYWORDS: RELEASE_TEAM_TEAMS}),
+        BasicChart("Previously served on the Kubernetes Release Team",
+                   ["Have you previously served on a Kubernetes Release Team?"],
+                   plotting_count_entities_up, {}),
+        BasicChart("How often applied to the release team",
+                   ["How many times have you applied to join the Release Team?"],
+                   plotting_count_entities_up, {}),
+        BasicChart("Release Team Roles Previously Served in",
+                   ["Which Release Team roles have you served in?"],
+                   plotting_count_entities_up, {CLEAN_SPLIT_INTO_KEYWORDS: RELEASE_TEAM_TEAMS, CLEAN_THRESHOLD: 2}),
+        BasicChart("Able to attend Release Team meetings",
+                   ["Will you be able to attend Release Team meetings? "],
+                   plotting_count_entities_up, {CLEAN_THRESHOLD: 2}),
+        BasicChart("Able to attend Burndown meetings",
+                   ["Will you be able to attend Burndown meetings?"],
+                   plotting_count_entities_up, {CLEAN_THRESHOLD: 2})
+    ]
 }
 
 # Info SummaryConfig:
@@ -92,11 +117,43 @@ SUMMARY_CONFIGS = {
          "Will you be able to attend Burndown meetings?": "Able to attend Burndown Meetings",
          "Are you interested in joining a Release Team stable roster": "Interested in the RT stable roster",
          "How many times have you applied to join the Release Team?": "Times applied to join the RT",
-         "Which Release Team roles are you interested for 1.25?": "Interested in Teams",
+         "Which Release Team roles are you interested for 1.26?": "Interested in Teams",
          "Which Release Team roles are you interested in?": "Interested in Teams"},
         # teams
         RELEASE_TEAM_TEAMS,
         # file_prefix
         "./applicants/"),
-    K8s_126: None
+    K8s_126: SummaryConfig(
+        # returner_column_name
+        "Have you previously served on a Kubernetes Release Team?",
+        # team_column_name
+        ["Which Release Team roles are you interested in?",
+         "Which Release Team roles are you interested for 1.26?"],
+        # deactivated_columns
+        ["Timestamp", "We would like to use your answers to produce anonymized reports about "
+                      "shadow applicants. Do you consent to your answers being used in a "
+                      "non-identifying way?"],
+        # column_rename
+        {"Goals.1": "Goals",
+         "To help address everyone correctly, please share your pronouns if you're comfortable doing so. You can read "
+         "more about pronoun sharing here https://www.mypronouns.org/sharing": "Pronouns",
+         "Contribution Plans.1": "Contribution Plans",
+         "Can you volunteer for 1.27 or 1.28?.1": "Can you volunteer for 1.27 or 1.28?",
+         "What time zone are you normally in?": "Timezone",
+         "What time zone are you normally in?.1": "Timezone",
+         "How many times have you applied to join the Release Team?:": "Times applied before",
+         "Have you read the role handbook associated with the role(s)?": "Read Handbook",
+         "Have you previously served on a Kubernetes Release Team?": "Previously served on the RT",
+         "How much time do you estimate you can commit to the Release Team a week? ": "Estimated Weekly Time commitment",
+         "Why are you interested in that role(s)?": "Why interested?",
+         "Will you be able to attend Release Team meetings? ": "Able to attend RT Meetings",
+         "Will you be able to attend Burndown meetings?": "Able to attend Burndown Meetings",
+         "Are you interested in joining a Release Team stable roster": "Interested in the RT stable roster",
+         "How many times have you applied to join the Release Team?": "Times applied to join the RT",
+         "Which Release Team roles are you interested for 1.26?": "Interested in Teams",
+         "Which Release Team roles are you interested in?": "Interested in Teams"},
+        # teams
+        RELEASE_TEAM_TEAMS,
+        # file_prefix
+        "./applicants/")
 }


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

This PR adds the configuration for the 1.26 release team shadow application form.

cc @palnabarun  