### PR TITLE
Sync owners with k/release

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - cpanato
-  - jeremyrickard
-  - justaugustus
-  - puerco
-  - saschagrunert
+  - sig-release-leads
+  - release-engineering-approvers
+
+reviewers:
+  - leonardpahlke
+  - release-engineering-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,23 @@
+aliases:
+  sig-release-leads:
+    - cpanato # SIG Technical Lead
+    - jeremyrickard # SIG Chair
+    - justaugustus # SIG Chair
+    - puerco # SIG Technical Lead
+    - saschagrunert # SIG Chair
+    - Verolop # SIG Technical Lead
+  release-engineering-approvers:
+    - cpanato # subproject owner / Release Manager
+    - jeremyrickard # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - palnabarun # Release Manager
+    - puerco # subproject owner / Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - xmudrii # Release Manager
+    - Verolop # subproject owner / Release Manager
+  release-engineering-reviewers:
+    - ameukam # Release Manager Associate
+    - cici37 # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - jrsapi # Release Manager Associate
+    - salaxander # Release Manager Associate


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

/kind cleanup

ref: https://github.com/kubernetes/sig-release/issues/2111

@saschagrunert I [saw your clean up](https://github.com/kubernetes-sigs/testgrid-json-exporter/pull/10) here and replicated that for this repo.
/cc @saschagrunert 